### PR TITLE
client-0.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16375,11 +16375,11 @@
         },
         "packages/client": {
             "name": "@gocontento/client",
-            "version": "0.0.10"
+            "version": "0.0.12"
         },
         "packages/next": {
             "name": "@gocontento/next",
-            "version": "0.0.10"
+            "version": "0.0.14"
         }
     }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gocontento/client",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Javascript client for Contento.io",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gocontento/client",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Javascript client for Contento.io",
   "repository": {
     "type": "git",

--- a/packages/client/src/lib/client.ts
+++ b/packages/client/src/lib/client.ts
@@ -5,6 +5,7 @@ interface ContentoClientConfig {
     apiURL: string;
     siteId: string;
     isPreview: boolean;
+    language?: string;
     fetchOptions?: object;
 }
 
@@ -179,6 +180,7 @@ export function createContentoClient({
     apiURL,
     siteId,
     isPreview = false,
+    language,
     fetchOptions = {},
 }: ContentoClientConfig) {
     const headers = new Headers({
@@ -188,6 +190,9 @@ export function createContentoClient({
     });
     if (isPreview) {
         headers.append('X-CONTENTO-PREVIEW', 'true');
+    }
+    if (language) {
+        headers.append('X-CONTENTO-LANGUAGE', language);
     }
 
     return ContentoClient({


### PR DESCRIPTION
- Adds a `language` option to `createContentoClient()`.
- Client now merges headers from `fetchOptions` properly.

The updated signature for `createContentoClient()` is now as follows:
```
createContentoClient({
  apiKey: string;
  apiURL: string;
  siteId: string;
  isPreview: boolean;
  language?: string | undefined;
  fetchOptions?: RequestInit | undefined;
});
```

You can use both options as follows:

```
createContentoClient({
  apiURL: process.env.CONTENTO_API_URL ?? '',
  apiKey: process.env.CONTENTO_API_KEY ?? '',
  siteId: process.env.CONTENTO_SITE_ID ?? '',
  isPreview: false,
  language: 'de',
  fetchOptions: {
    headers: {
      'X-FOO': 'bar'
    }
  }
})
```